### PR TITLE
Oppdater openldap

### DIFF
--- a/ldap/Dockerfile
+++ b/ldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM osixia/openldap:1.2.1
+FROM osixia/openldap:1.5.0
 
 ADD sAMAccountName.schema /container/service/slapd/assets/config/bootstrap/schema/custom/s_ama_account_name.schema
 ADD acl.ldif /container/service/slapd/assets/config/bootstrap/ldif/custom/110-acl.ldif


### PR DESCRIPTION
Den eldre versjonen fungerer ikke for M1 mac/ARM